### PR TITLE
Enable passing parameters through to queries

### DIFF
--- a/snapquery/snapquery_core.py
+++ b/snapquery/snapquery_core.py
@@ -553,17 +553,17 @@ class QueryBundle:
         )
         return response.text
 
-    def get_lod(self) -> List[dict]:
+    def get_lod(self, *, param_dict=None) -> List[dict]:
         """
         Executes the stored query using the SPARQL service and returns the results as a list of dictionaries.
 
         Returns:
             List[dict]: A list where each dictionary represents a row of results from the SPARQL query.
         """
-        lod = self.sparql.queryAsListOfDicts(self.query.query)
+        lod = self.sparql.queryAsListOfDicts(self.query.query, param_dict=param_dict)
         return lod
 
-    def get_lod_with_stats(self) -> tuple[list[dict], QueryStats]:
+    def get_lod_with_stats(self, *, param_dict=None) -> tuple[list[dict], QueryStats]:
         """
         Executes the stored query using the SPARQL service and returns the results as a list of dictionaries.
 
@@ -573,7 +573,7 @@ class QueryBundle:
         logger.info(f"Querying {self.endpoint.name} with query {self.named_query.name}")
         query_stat = QueryStats(query_id=self.named_query.query_id, endpoint_name=self.endpoint.name)
         try:
-            lod = self.sparql.queryAsListOfDicts(self.query.query)
+            lod = self.sparql.queryAsListOfDicts(self.query.query, param_dict=param_dict)
             query_stat.records = len(lod) if lod else -1
             query_stat.done()
         except Exception as ex:

--- a/snapquery/snapquery_webserver.py
+++ b/snapquery/snapquery_webserver.py
@@ -208,7 +208,6 @@ class SnapQueryWebServer(InputWebserver):
                 raise HTTPException(status_code=500, detail="Could not create result")
 
             if format == Format.json:
-                print(content)
                 return JSONResponse(json.loads(content))
 
             return content

--- a/snapquery/snapquery_webserver.py
+++ b/snapquery/snapquery_webserver.py
@@ -5,6 +5,7 @@ Created on 2024-05-03
 
 from pathlib import Path
 
+import fastapi
 from fastapi import HTTPException
 from fastapi.responses import HTMLResponse, PlainTextResponse
 from lodstorage.query import Format
@@ -179,6 +180,7 @@ class SnapQueryWebServer(InputWebserver):
 
         @app.get("/api/query/{domain}/{namespace}/{name}")
         def query(
+            request: fastapi.Request,
             domain: str,
             namespace: str,
             name: str,
@@ -207,6 +209,7 @@ class SnapQueryWebServer(InputWebserver):
                 domain=domain,
                 endpoint_name=endpoint_name,
                 limit=limit,
+                param_dict=request.query_params,
             )
             if not content:
                 raise HTTPException(status_code=500, detail="Could not create result")

--- a/snapquery/snapquery_webserver.py
+++ b/snapquery/snapquery_webserver.py
@@ -242,6 +242,7 @@ class SnapQueryWebServer(InputWebserver):
         domain: str,
         endpoint_name: str = "wikidata",
         limit: int = None,
+        param_dict=None,
     ) -> str:
         """
         Queries an external API to retrieve data based on a given namespace and name.
@@ -261,7 +262,7 @@ class SnapQueryWebServer(InputWebserver):
             name, r_format = self.get_r_format(name)
             query_name = QueryName(domain=domain, namespace=namespace, name=name)
             qb = self.nqm.get_query(query_name=query_name, endpoint_name=endpoint_name, limit=limit)
-            (qlod, stats) = qb.get_lod_with_stats()
+            (qlod, stats) = qb.get_lod_with_stats(param_dict=param_dict)
             self.nqm.store_stats([stats])
             content = qb.format_result(qlod, r_format)
             return content

--- a/snapquery/snapquery_webserver.py
+++ b/snapquery/snapquery_webserver.py
@@ -202,11 +202,13 @@ class SnapQueryWebServer(InputWebserver):
                 endpoint_name=endpoint_name,
                 limit=limit,
                 param_dict=request.query_params,
+                format=format,
             )
             if not content:
                 raise HTTPException(status_code=500, detail="Could not create result")
 
             if format == Format.json:
+                print(content)
                 return JSONResponse(json.loads(content))
 
             return content
@@ -240,6 +242,7 @@ class SnapQueryWebServer(InputWebserver):
         endpoint_name: str = "wikidata",
         limit: int = None,
         param_dict=None,
+        format=None,
     ) -> str:
         """
         Queries an external API to retrieve data based on a given namespace and name.
@@ -257,6 +260,8 @@ class SnapQueryWebServer(InputWebserver):
         try:
             # content negotiation
             name, r_format = self.get_r_format(name)
+            if format:
+                r_format = format
             query_name = QueryName(domain=domain, namespace=namespace, name=name)
             qb = self.nqm.get_query(query_name=query_name, endpoint_name=endpoint_name, limit=limit)
             (qlod, stats) = qb.get_lod_with_stats(param_dict=param_dict)


### PR DESCRIPTION
You can see the changes after running `snapquery --serve`. This includes the following:

1. Make sure `param_dict` can be passed around
2. Make FastAPI parameters get documented nicely in http://localhost:9862/docs
3. Enable arbitrary parameters to be passed through, this means that the following works:
   ```python
   import requests
   res = requests.get(
        "http://localhost:9862/api/query/scholia.toolforge.org/"
        "named_queries/author_list-of-publications?q=Q47475003"
   )
   ```
   Note, this isn't perfect, since the API can't know what to document ahead of time, so you just have to know what your query needs.
4. Enable passing the format via the `format` query parameter.